### PR TITLE
Add cli for cifraclub

### DIFF
--- a/cli/cifra.py
+++ b/cli/cifra.py
@@ -1,0 +1,22 @@
+import typer
+import os
+import requests
+import decorating
+
+CIFRACLUB_API_URL = os.getenv("CIFRACLUB_API_URL", "http://localhost:3000")
+app = typer.Typer()
+
+@app.command()
+def get(artist: str, song: str):
+    get_endpoint = CIFRACLUB_API_URL + f"/artists/{artist}/songs/{song}"
+    with decorating.writing(delay=0.02):
+        print(f"Carregando música {song} do artista {artist}...")
+    with decorating.animated("carregando cifra"):
+        response = requests.get(get_endpoint)
+    response_json = response.json()
+    for text_line in response_json["cifra"]:
+        print(text_line)
+
+
+if __name__ == '__main__':
+    app()

--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -1,0 +1,3 @@
+typer
+requests
+decorating

--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -1,3 +1,3 @@
-typer
-requests
-decorating
+typer==0.7.0
+requests==2.28.1
+decorating==0.6.1


### PR DESCRIPTION
- Simple cli using [typer] command line interface framework
- Use some spinners and animation to make interating greater by using package [decorating]

[typer]: https://typer.tiangolo.com/
[decorating]: https://github.com/ryukinix/decorating
How to install and use in the root of the repository:

- pip install -r cli/requirements.txt
- `python cli/cifra.py <artist> <song>`

Usually, the artist and song words are separated by hyphens.

![image](https://user-images.githubusercontent.com/7642878/204155437-1e2ec8d7-e989-4830-87ad-f749d06e0ee1.png)
